### PR TITLE
Fixed a bug in parse_anarci

### DIFF
--- a/scripts/parse_tcr_seq.py
+++ b/scripts/parse_tcr_seq.py
@@ -14,7 +14,8 @@ def parse_anarci(in_seq):
         command = "ANARCI --scheme aho -i %s" % in_seq
         output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
         output = output.decode("utf-8")  # decode bytes to string
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
+        print(f"ANARCI failed for {in_seq} with error: {e.output.decode('utf-8')}")
         return "NA", "NA"
 
     cdr3, seq = "", ""

--- a/scripts/parse_tcr_seq.py
+++ b/scripts/parse_tcr_seq.py
@@ -4,44 +4,43 @@ from anarci import anarci
 
 
 def get_seq(pdb_chain):
-    command="grep -A1 %s data/databases/pdb_seqres.txt" % (pdb_chain)
+    command = "grep -A1 %s data/databases/pdb_seqres.txt" % (pdb_chain)
     output = subprocess.getoutput(command)
     return output.split("\n")[1]
 
 
 def parse_anarci(in_seq):
     try:
-        command="ANARCI --scheme aho -i %s" % in_seq
+        command = "ANARCI --scheme aho -i %s" % in_seq
         output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
         output = output.decode("utf-8")  # decode bytes to string
     except subprocess.CalledProcessError:
         return "NA", "NA"
 
-    cdr3, seq="",""
+    cdr3, seq = "", ""
     for i in output.split("\n"):
         if i and i[0] != "#" and i[0] != "/":
             _, num, res = i.rstrip().split()
             num = int(num)
             if res != "-":
+                seq += res
                 if num >= 106 and num <= 139:
                     cdr3 += res
-                else:
-                    seq += res
     return cdr3, seq
 
 
-def get_germlines(seq:str):
-    '''
+def get_germlines(seq: str):
+    """
     Get the VJ germlines from TCRa or TCRb sequences
-    '''
-    input_seq = [('seq',seq)]
+    """
+    input_seq = [("seq", seq)]
     try:
         results = anarci(input_seq, scheme="aho", output=False, assign_germline=True)
-        v_gene = results[1][0][0]['germlines']['v_gene'][0][1]
-        j_gene = results[1][0][0]['germlines']['j_gene'][0][1]
+        v_gene = results[1][0][0]["germlines"]["v_gene"][0][1]
+        j_gene = results[1][0][0]["germlines"]["j_gene"][0][1]
     except:
-        v_gene = 'NA'
-        j_gene = 'NA'
+        v_gene = "NA"
+        j_gene = "NA"
     return v_gene, j_gene
 
 
@@ -49,4 +48,3 @@ def parse_tcr(in_seq):
     cdr3, seq = parse_anarci(in_seq)
     v_gene, j_gene = get_germlines(in_seq)
     return [cdr3, seq, v_gene, j_gene]
-

--- a/scripts/parse_tcr_seq.py
+++ b/scripts/parse_tcr_seq.py
@@ -4,21 +4,21 @@ from anarci import anarci
 
 
 def get_seq(pdb_chain):
-    command = "grep -A1 %s data/databases/pdb_seqres.txt" % (pdb_chain)
+    command="grep -A1 %s data/databases/pdb_seqres.txt" % (pdb_chain)
     output = subprocess.getoutput(command)
     return output.split("\n")[1]
 
 
 def parse_anarci(in_seq):
     try:
-        command = "ANARCI --scheme aho -i %s" % in_seq
+        command="ANARCI --scheme aho -i %s" % in_seq
         output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
         output = output.decode("utf-8")  # decode bytes to string
     except subprocess.CalledProcessError as e:
         print(f"ANARCI failed for {in_seq} with error: {e.output.decode('utf-8')}")
         return "NA", "NA"
 
-    cdr3, seq = "", ""
+    cdr3, seq="",""
     for i in output.split("\n"):
         if i and i[0] != "#" and i[0] != "/":
             _, num, res = i.rstrip().split()
@@ -30,18 +30,18 @@ def parse_anarci(in_seq):
     return cdr3, seq
 
 
-def get_germlines(seq: str):
-    """
+def get_germlines(seq:str):
+    '''
     Get the VJ germlines from TCRa or TCRb sequences
-    """
-    input_seq = [("seq", seq)]
+    '''
+    input_seq = [('seq',seq)]
     try:
         results = anarci(input_seq, scheme="aho", output=False, assign_germline=True)
-        v_gene = results[1][0][0]["germlines"]["v_gene"][0][1]
-        j_gene = results[1][0][0]["germlines"]["j_gene"][0][1]
+        v_gene = results[1][0][0]['germlines']['v_gene'][0][1]
+        j_gene = results[1][0][0]['germlines']['j_gene'][0][1]
     except:
-        v_gene = "NA"
-        j_gene = "NA"
+        v_gene = 'NA'
+        j_gene = 'NA'
     return v_gene, j_gene
 
 
@@ -49,3 +49,4 @@ def parse_tcr(in_seq):
     cdr3, seq = parse_anarci(in_seq)
     v_gene, j_gene = get_germlines(in_seq)
     return [cdr3, seq, v_gene, j_gene]
+


### PR DESCRIPTION
@ryin222 Sorry, I accidentally introduced a bug in how the `seq` is defined (it didn't contain `cdr3` after my changes in #4 ).

- Fixed a bug in `parse_anarci` introduced in #4 
- Added a more informative error message.