### PR TITLE
Update parse_anarci to handle insertion codes in AHo numbering from ANARCI output.

### DIFF
--- a/scripts/parse_tcr_seq.py
+++ b/scripts/parse_tcr_seq.py
@@ -19,14 +19,18 @@ def parse_anarci(in_seq):
         return "NA", "NA"
 
     cdr3, seq="",""
-    for i in output.split("\n"):
-        if i and i[0] != "#" and i[0] != "/":
-            _, num, res = i.rstrip().split()
-            num = int(num)
-            if res != "-":
-                seq += res
-                if num >= 106 and num <= 139:
-                    cdr3 += res
+    for line in output.split("\n"):
+        if line and line[0] != "#" and line[0] != "/":
+            try:
+                fields = line.rstrip().split()
+                num = int(fields[1])    # Second field for residue_number
+                res = fields[-1]        # Last field for aa
+                if res != "-":
+                    seq += res
+                    if num >= 106 and num <= 139:
+                        cdr3 += res
+            except (ValueError, IndexError) as e:
+                print(f"Error parsing line '{line.strip()}': {str(e)}")
     return cdr3, seq
 
 
@@ -49,4 +53,5 @@ def parse_tcr(in_seq):
     cdr3, seq = parse_anarci(in_seq)
     v_gene, j_gene = get_germlines(in_seq)
     return [cdr3, seq, v_gene, j_gene]
+
 


### PR DESCRIPTION
Update parse_anarci to use fields[1] for residue_number  and fields[-1] for reside_code instead of unpacking.
Update parse_anarci to print parsing errors instead of silently quitting; log error details for ValueError/IndexError