### PR TITLE
Fix cuda 12.2 container

### DIFF
--- a/run_alphafold_tcrmodel2.3.py
+++ b/run_alphafold_tcrmodel2.3.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 # Copyright 2021 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/run_tcrmodel2.py
+++ b/run_tcrmodel2.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 # Load required packages
 # import pandas as pd
 import json

--- a/run_tcrmodel2_ub_tcr.py
+++ b/run_tcrmodel2_ub_tcr.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 # Load required packages
 import os
 import sys

--- a/singularity/tcrmodel2_singularity_cuda12-2.def
+++ b/singularity/tcrmodel2_singularity_cuda12-2.def
@@ -1,96 +1,84 @@
 BootStrap: docker
 From: nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu20.04
 
-%post
-# install dependencies
-apt-get update && DEBIAN_FRONTEND=noninteractive TZ="America/Sao_Paulo" \
-apt-get install -y --no-install-recommends \
-    build-essential \
-    cmake \
-    cuda-command-line-tools-12-2 \
-    git \
-    hmmer \
-    kalign \
-    tzdata \
-    wget \
-&& rm -rf /var/lib/apt/lists/* \
-&& apt-get autoremove -y \
-&& apt-get clean
+%files
+    ./alphafold /opt/src/alphafold
+    ./scripts /opt/src/scripts
+    ./data /data
+    ./run_alphafold_tcrmodel2.3.py /root/.local/bin/run_alphafold_tcrmodel2.3
+    ./run_tcrmodel2.py /root/.local/bin/run_tcrmodel2
+    ./run_tcrmodel2_ub_tcr.py /root/.local/bin/run_tcrmodel2_ub_tcr
+    ./run_tcrmodel2_ub_pmhc.py /root/.local/bin/run_tcrmodel2_ub_pmhc
 
-# compile and install HH-suite
-git clone --branch v3.3.0 https://github.com/soedinglab/hh-suite.git /opt/hh-suite \
-    && mkdir /opt/hh-suite/build \
-    && cd /opt/hh-suite/build \
-    && cmake -DCMAKE_INSTALL_PREFIX=/opt/hhsuite .. \
-    && make -j 4 && make install \
-    && ln -s /opt/hhsuite/bin/* /usr/bin \
-    && cd \
-    && rm -rf /opt/hh-suite
+%post -c /bin/bash
+    apt-get update
+    apt-get install -y build-essential curl git
 
-# install miniconda
-wget -P /tmp \
-    "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" \
-    && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \
-    && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
+    "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+    export PATH=/root/micromamba/bin/:/root/.local/bin/:$PATH
 
-export PATH=/opt/conda/bin:$PATH
+    micromamba install python==3.11 pip=25.2 -y
+    micromamba install -y -c conda-forge \
+        openmm==8.0.0 \
+        pdbfixer
+    micromamba install -y -c nvidia/label/cuda-12.2.2 cuda-toolkit
+    micromamba install -y -c bioconda \
+        hhsuite==3.3.0 \
+        hmmer \
+        kalign2
 
-conda install -qy conda==24.1.2 pip python=3.11 \
-    && conda install -y -c conda-forge -c bioconda \
-      openmm=8.0.0 \
-      pdbfixer \
-      mock \
-      anarci \
-      absl-py=0.13.0 \
-    && conda install -y nvidia/label/cuda-12.2.2::cuda-toolkit -c nvidia/label/cuda-12.2.2 \
-    && conda clean --all --force-pkgs-dirs --yes
+    pip install \
+        absl-py==1.0.0 \
+        biopython==1.79 \
+        chex==0.0.7 \
+        dm-haiku==0.0.12 \
+        dm-tree==0.1.8 \
+        immutabledict==2.0.0 \
+        jax==0.4.26 \
+        ml-collections==0.1.0 \
+        numpy \
+        pandas==1.3.4 \
+        scipy==1.11.1 \
+        tensorflow-cpu==2.16.1
 
-#&& conda install -y -c nvidia cuda=12.2.2 \
+    pip install \
+        --upgrade \
+        --no-cache-dir \
+        jax==0.4.26 \
+        jaxlib==0.4.26+cuda12.cudnn89 \
+        -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
-cd /opt
-git clone https://github.com/deepmind/alphafold
-git -C /opt/alphafold reset --hard f251de6
-wget -q -P /opt/alphafold/alphafold/common/ \
-    https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
+    micromamba install -c conda-forge mdanalysis
 
-pip3 install --upgrade pip --no-cache-dir \
-    && pip3 install -r /opt/alphafold/requirements.txt --no-cache-dir \
-    && pip3 install --upgrade --no-cache-dir \
-      jax==0.4.26 \
-      jaxlib==0.4.26+cuda12.cudnn89 \
-      -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
-    && pip3 install tensorflow==2.16.* --no-cache-dir
+    pip install --force-reinstall charset_normalizer
 
-#Install MDanalysis with pip
-pip3 install --upgrade MDAnalysis
+    git clone https://github.com/oxpig/ANARCI.git /opt/anarci
+    cd /opt/anarci
+    python setup.py install
 
-#Setting up TCRmodel2
-cd /opt
-git clone https://github.com/piercelab/tcrmodel2
+    # Change Hard-coded paths in scripts
+    sed -i 's+data/databases+/data/databases+g' /opt/src/scripts/parse_tcr_seq.py
+    sed -i 's+data/databases+/data/databases+g' /opt/src/scripts/parse_tcr_seq_from_json.py
+    sed -i 's+data/templates+/data/templates+g' /opt/src/scripts/pmhc_templates.py
+    sed -i 's+"[.]"+"/opt/src"+g' /root/.local/bin/run_tcrmodel2
+    sed -i 's+"[.]"+"/opt/src"+g' /root/.local/bin/run_tcrmodel2_ub_pmhc
+    sed -i 's+python run_alphafold_tcrmodel2.3.py+run_alphafold_tcrmodel2.3+g' /root/.local/bin/run_tcrmodel2
+    sed -i 's+python run_alphafold_tcrmodel2.3.py+run_alphafold_tcrmodel2.3+g' /root/.local/bin/run_tcrmodel2_ub_tcr
+    sed -i 's+python run_alphafold_tcrmodel2.3.py+run_alphafold_tcrmodel2.3+g' /root/.local/bin/run_tcrmodel2_ub_pmhc
 
-#change some paths
-sed -i 's+data/databases/+/opt/tcrmodel2/data/databases/+g' /opt/tcrmodel2/scripts/parse_tcr_seq.py
-sed -i 's+data/databases/+/opt/tcrmodel2/data/databases/+g' /opt/tcrmodel2/scripts/parse_tcr_seq_from_json.py
-sed -i 's+data/templates/+/opt/tcrmodel2/data/templates/+g' /opt/tcrmodel2/scripts/pmhc_templates.py
-sed -i 's+"[.]"+"/opt/tcrmodel2/"+g' /opt/tcrmodel2/run_tcrmodel2.py
-sed -i 's+run_alphafold_tcrmodel2.3.py+/opt/tcrmodel2/run_alphafold_tcrmodel2.3.py+g' /opt/tcrmodel2/run_tcrmodel2.py
-sed -i 's+simtk.openmm+openmm+g' /opt/tcrmodel2/alphafold/relax/amber_minimize.py
-sed -i 's+simtk.openmm+openmm+g' /opt/tcrmodel2/alphafold/relax/amber_minimize.py
-sed -i 's+from simtk import openmm+import openmm+g' /opt/tcrmodel2/alphafold/relax/amber_minimize.py
-sed -i 's+from simtk import unit+from openmm import unit+g' /opt/tcrmodel2/alphafold/relax/amber_minimize.py
-sed -i 's+simtk.openmm+openmm+g' /opt/tcrmodel2/alphafold/relax/utils.py
-cd /opt/tcrmodel2/data/databases
-tar -xvzf pdb_seqres.txt.tar.gz
-cd -
-
-# Add SETUID bit to the ldconfig binary so that non-root users can run it.
-chmod u+s /sbin/ldconfig.real
+    # Change import calls in alphafold
+    sed -i 's+from simtk import openmm+import openmm+g' /opt/src/alphafold/relax/amber_minimize.py
+    sed -i 's+from simtk import unit+from openmm import unit+g' /opt/src/alphafold/relax/amber_minimize.py
+    sed -i 's+simtk.openmm+openmm+g' /opt/src/alphafold/relax/amber_minimize.py
+    sed -i 's+simtk.openmm+openmm+g' /opt/src/alphafold/relax/cleanup.py
 
 %environment
-export PATH=/opt/conda/bin:$PATH
+    export PATH=/root/micromamba/bin/:/root/.local/bin/:$PATH
+    export PYTHONPATH=/opt/src/:${PYTHONPATH}
 
 %runscript
-python3 /opt/tcrmodel2/run_tcrmodel2.py $@
+    #! /bin/bash
+    run_tcrmodel2 "$@"
 
 %labels
     Maintainer "Helder/ Pierce Lab"
@@ -98,3 +86,4 @@ python3 /opt/tcrmodel2/run_tcrmodel2.py $@
     Release "1"
     Summary "TCRModel2"
     OS "ubuntu:20.04"
+    CUDA 12.2.2-cudnn8


### PR DESCRIPTION
Hi there,

This PR modifies the cuda 12-2 container specification to get it working.

I encountered some issues while trying to use TCRmodel2 with the cuda 12-2 container with the current spec.

## Steps to reproduce

```
# from the tcrmodel2 directory
sudo singularity build tcrmodel2.sif singularity/tcrmodel2_singularity_cuda12-2.def 1> container_build_log.txt 2>&1
... # Ammend script with correct file paths
bash singularity/run_tcrmodel2_singularity.sh
```

Gives this error:

```
Traceback (most recent call last):
  File "/opt/tcrmodel2/run_tcrmodel2.py", line 9, in <module>
    from absl import app, flags
ModuleNotFoundError: No module named 'absl'
```

Here is the container build log: [container_build_log.txt](https://github.com/user-attachments/files/23420837/container_build_log.txt). There are a couple of failing steps.